### PR TITLE
0x05 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Arduino library to communicate with the murata lorawan board.
+Arduino library to communicate with the lorawan module Murata [ST B-L072Z-LRWAN1](https://www.st.com/en/evaluation-tools/b-l072z-lrwan1.html) or the [Miromico FMLR-72-U-STL0Z](https://miromico.ch/portfolio/fmlr_stm/).
 
 ### Wiring
 


### PR DESCRIPTION
- avoid the serial to hang on 0x05 (busy) state when joining
- linked to the modules supported in the readme

"1 bug 2 fixes":
- read requests getting a 0x05 should not hang anymore, as we read all data coming from serial before returning
- check for the status of the module before doing a join request if joined or is_joining. If joining we'll still see a blocking status progress